### PR TITLE
Fixing spelling error in aboutcontroller

### DIFF
--- a/visualization/gae/scripts/controllers.js
+++ b/visualization/gae/scripts/controllers.js
@@ -12,7 +12,7 @@ app.controller("HomeCtrl", function ($scope, Category, Project) {
     });
 });
 
-app.controller("AbouCtrl", function ($scope) {
+app.controller("AboutCtrl", function ($scope) {
     
 });
 


### PR DESCRIPTION
There is a spelling error in the name for the AboutController. Inserted a 't' so AbouController becomes AboutController.
