### PR TITLE
delay text search by 500ms

### DIFF
--- a/visualization/gae/scripts/directives.js
+++ b/visualization/gae/scripts/directives.js
@@ -56,10 +56,6 @@ angular.module('ossrank.directives',[]).directive('autoComplete',['$http',functi
             }
 
             scope.search=function() {
-                // search only for 3 or more characters
-                if (scope.searchText.length < 3)
-                    return;
-                
                 $http.get(attrs.url+'?term='+scope.searchText).success(function(data){
                     if(data.indexOf(scope.searchText)===-1){
                         data.unshift(scope.searchText);

--- a/visualization/gae/views/autocomplete-template.html
+++ b/visualization/gae/views/autocomplete-template.html
@@ -2,7 +2,8 @@
 <div class="row">
 <div class="col-xs-4 top-buffer">
     <h4>Search</h4>
-    <input type="text" placeholder="Enter keywords" id="searchInput" ng-keydown="checkKeyDown($event)" class="form-control" ng-model="searchText" ng-change="search()"/>
+    <input type="text" placeholder="Enter keywords" id="searchInput" ng-keydown="checkKeyDown($event)" 
+        class="form-control" ng-model="searchText" ng-change="search()" ng-model-options="{debounce: 500}"/>
     <ul id="suggestions" class="suggestions-list">
        <li ng-repeat="suggestion in suggestions" class="blockSpan" 
            ng-click="addToSelectedTags($index)" ng-mouseover="$parent.selectedIndex=$index" 


### PR DESCRIPTION
So users can do search also for shorter strings without overloading the backend... let's see how it feels.
Fixes #68 
