### PR TITLE
Parallelizing R job ..depending on available cores

### DIFF
--- a/ranker/r/OSSRank_CalculateScore_REST.R
+++ b/ranker/r/OSSRank_CalculateScore_REST.R
@@ -5,20 +5,61 @@ library(yaml)
 library(curl)
 library(httr)
 library(rjson)
-
+library(foreach)
+library(doSNOW)
+library(parallel)
+# infuture to improve the code with parallel library
 
 
 #function to get configuration
 readConfiguration <- function(){
-  config=yaml.load_file("config.yml")
+  config=yaml:::yaml.load_file("config.yml")
   return (config)
+}
+
+#get collection length..used for number of iteration to perform on data
+getProjectCollectionSize <- function(){
+  collectionLengthFindURL <-paste(readConfiguration()$apiURL,readConfiguration()$database,"/collections/",readConfiguration()$collection,"?apiKey=",readConfiguration()$apiKey,"&c=true",sep="")
+  collectionSize <- curl(collectionLengthFindURL)%>% jsonlite ::: fromJSON()
+  #print()
+  return(as.integer(collectionSize))
+}
+
+#Number of iteration to perform
+# to process full data dump
+getNumIterations <- function(){
+  total_document_num <- getProjectCollectionSize()
+  
+  print(total_document_num)
+  
+  if((total_document_num %% readConfiguration()$processing_chunk) == 0){
+    
+      return((total_document_num / readConfiguration()$processing_chunk))  
+  
+    }else{
+    
+      return((total_document_num %/% readConfiguration()$processing_chunk)+1)  
+  }
+  
+}
+
+
+
+#verify if platform is windows
+isPlatformWindows <- function(){
+  return(grep("Windows",Sys.getenv("OS"),ignore.case = TRUE) ==1)
+}
+
+#get number of cores..used for creating cluster to run the job parallely
+getNumberOfCores <- function(){
+  return(parallel:::detectCores())
 }
 
 
 # Create REST URL to fetch the data
 #        the REST URL is mongolab specific
-getProejctBaseURL <-function(){
-  baseURL <-paste(readConfiguration()$apiURL,readConfiguration()$database,"/collections/",readConfiguration()$collection,"?apiKey=",readConfiguration()$apiKey,"&l=10",sep="")
+getProejctBaseURL <-function(numOfDocumentToSkip){
+  baseURL <-paste(readConfiguration()$apiURL,readConfiguration()$database,"/collections/",readConfiguration()$collection,"?apiKey=",readConfiguration()$apiKey,"&sk=",as.character(numOfDocumentToSkip),"&l=",readConfiguration()$processing_chunk,sep="")
   print(baseURL)
   return (baseURL)    
 }
@@ -28,7 +69,7 @@ getProejctBaseURL <-function(){
 getPostURL <- function(documentId){
   
   postURL <-paste(readConfiguration()$apiURL,readConfiguration()$database,"/collections/",readConfiguration()$collection,"/",as.character(documentId),"?apiKey=",readConfiguration()$apiKey,sep="")
-  print(postURL)
+  #print(postURL)
   return(as.character(postURL))
   
 }
@@ -43,13 +84,14 @@ norm2 <- function(x) {
 #Commit a document to repository
 #   update document in mongolab
 commitDataToRepository_rest <- function(documentId,jsonData){
-  dataReq <- PUT(getPostURL(documentId),
-             add_headers(
+  dataReq <- httr:::PUT(getPostURL(documentId),
+             httr:::add_headers(
                 "Content-Type" = "application/json;charset=utf-8"
               ),
-              body = jsonData
+             body = jsonData
   );
-  print(http_status(dataReq))
+  status <- httr:::http_status(dataReq)
+  print(status)
 }
 
 # Function to return difference between currentdate and specified date in days
@@ -121,49 +163,60 @@ addProjectScore <- function(aProject,ossrankScore){
   
   scoreList <- list(scoreDf)
   #append score to project 
-  aProject[scoreElement] <- scoreList 
+  aProject[scoreElement] <- as.double(ossrankScore) 
   
   return(aProject)
   
 }
 
 
+getProjectCollectionSize()
 
 
-#get a dataframe of project objects
-projects<- curl(getProejctBaseURL()) %>% jsonlite ::: fromJSON()
 
-#documentId <- res[1,"_id.$oid"]
-#oid<-documentId[1,]
+#parallelized loop..as many cores available to the machine
+current_cluster<- makeCluster(getNumberOfCores()) #set number of cores
+registerDoSNOW(current_cluster)
 
-#normalizedScoreList <- lapply(data.frame(c(2,34,67,99)),norm2)
-#sumScore<-unlist(lapply(normalizedScoreList,function(x) sum(x)))
+iteration_length <- getNumIterations()
 
-#projData<-toJSON(res[1,],pretty= TRUE)
-
-#is this looping first , need to parallelize
-
-for(i in 1:nrow(projects)){
+skipDocument <- 0
+for(it in 1:iteration_length){
   
+    
+  #get a dataframe of project objects
+  projects<- curl(getProejctBaseURL(skipDocument)) %>% jsonlite ::: fromJSON()
   
-  if("_twitter" %in% colnames(projects[i,]))
-  {
-    tweet_length <- length(projects[i,"_twitter"])
-    last_tweets_num <- as.numeric(projects[i,"_twitter"][1,tweet_length])
-  } else{
-    last_tweets_num <- 0
-  } 
+  skipDocument <- skipDocument + as.integer(readConfiguration()$processing_chunk)
   
-  ossrank_score <- calCulateProjectScore(projects[i,],last_tweets_num)
-  updatedProject <- addProjectScore(projects[i,],ossrank_score)
-  projData<- rjson ::: toJSON(updatedProject)
+
+  #foreach parallely is using %dopar% works only registerred cluster 
+  #the code will shift to sequential if no cluster is registerred 
+  #or only 1 core found
+
+  foreach (i=1:nrow(projects)) %dopar% {
   
-  project_documentId_mongo <- getProjectDocumentId(projects[i,])
+    if("_twitter" %in% colnames(projects[i,]))
+    {
+      tweet_length <- length(projects[i,"_twitter"])
+      last_tweets_num <- as.numeric(projects[i,"_twitter"][1,tweet_length])
+    } else{
+      last_tweets_num <- 0
+    } 
   
-  commitDataToRepository_rest(project_documentId_mongo,projData)
+    ossrank_score <- calCulateProjectScore(projects[i,],last_tweets_num)
+    updatedProject <- addProjectScore(projects[i,],ossrank_score)
+    projData<- rjson ::: toJSON(updatedProject)
   
+    project_documentId_mongo <- getProjectDocumentId(projects[i,])
+    #print(projects[i,"name"] )
+    commitDataToRepository_rest(project_documentId_mongo,projData)
+  
+  }
+
 }
 
+stopCluster(current_cluster)
 
 
 

--- a/ranker/r/config.yml
+++ b/ranker/r/config.yml
@@ -4,8 +4,8 @@
   port : 
   user : 
   password : 
-  apiURL : https://api.mongolab.com/api/1/databases/
+  apiURL : https://api.mlab.com/api/1/databases/
   apiKey : 
   database : 
   collection : projects
-
+  processing_chunk : 500


### PR DESCRIPTION
This updates actually make sure we can complete scoring job once started automatically,earlier job had to be restarted manually after a specific iteration sequentially.
This code actually determines how many iterations to go based on a chunk size in yml and then paralleize each chunk processing based on number of cores available in the running machine.
